### PR TITLE
Update unique_combination_of_columns.sql

### DIFF
--- a/macros/generic_tests/unique_combination_of_columns.sql
+++ b/macros/generic_tests/unique_combination_of_columns.sql
@@ -20,7 +20,7 @@
 {%- set columns_csv=column_list | join(', ') %}
 
 
-with validation_errors as (
+with test_table as (
 
     select
         {{ columns_csv }}
@@ -30,8 +30,9 @@ with validation_errors as (
 
 )
 
-select *
-from validation_errors
+select 
+  {{ columns_csv }}
+from test_table
 
 
 {% endmacro %}


### PR DESCRIPTION
explicitly list columns in unique_combination query

resolves #

### Problem

We need to explicitly list columns in the query 

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

## Checklist
- [ ] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)
